### PR TITLE
Events Collecto procedure renaming

### DIFF
--- a/buda/services/events_collector.proto
+++ b/buda/services/events_collector.proto
@@ -5,7 +5,7 @@ package buda.services;
 import "buda/entities/funnel.proto";
 
 service EventsCollector {
-  rpc TrackFunnelEvent (buda.entities.FunnelEvent) returns (Response) {}
+  rpc CollectFunnelEvent (buda.entities.FunnelEvent) returns (Response) {}
 }
 
 message Response {


### PR DESCRIPTION
The name `CollectFunnelEvent` feels more aligned with `EventsCollector` as @michael-erasmus suggested in https://github.com/bufferapp/buda-protobufs/issues/2.

Closes #2 