### PR TITLE
Publish 0.4.5 on npm. Update publish script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
 # Buffer Unified Data Architecture Protocol Buffers
 
+[![npm version](https://badge.fury.io/js/%40bufferapp%2Fbuda.svg)](https://badge.fury.io/js/%40bufferapp%2Fbuda)
+
 Central repository where Buffer's Data Architecture protobufs live.
 
 ## Resources
 
 You can learn more about protobufs in the [Protobuf official repository](https://github.com/google/protobuf).
+
+## Publishing
+
+To publish the node package on npm run:
+
+```
+./scripts/publish-node.sh
+```
+
+For a beta channel release run:
+
+```
+./scripts/publish-node.sh beta
+```

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/buda",
-  "version": "0.1.1-beta-8",
+  "version": "0.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/buda",
-  "version": "0.1.1-beta-12",
+  "version": "0.4.5",
   "description": "The protobufs for the Buffer Unified Data Architecture",
   "main": "index.js",
   "scripts": {

--- a/scripts/publish-node.sh
+++ b/scripts/publish-node.sh
@@ -1,3 +1,30 @@
 #!/usr/bin/env sh
 
-docker run -it --rm -v $PWD/.npmrc:/root/.npmrc -v $PWD/packages/node:/app -w /app node:8 npm publish --tag beta 
+VERSION=$(cat VERSION)
+ARG="$1"
+NPMRC_PATH="$HOME/.npmrc"
+
+# For beta release: ./scripts/publish-node.sh beta
+if [ $ARG == "beta" ]; then
+    COMMAND="npm publish --tag beta"
+else
+    COMMAND="npm publish"
+fi
+
+if [ ! -f $NPMRC_PATH ]; then
+    NPMRC_PATH="$PWD/.npmrc"
+    if [ ! -f $NPMRC_PATH ]; then
+        echo ".npmrc file not found, please run ./scripts/npm-login.sh"
+        exit 1
+    fi
+fi
+
+echo "Publishing @bufferapp/buda@$VERSION"
+echo "$COMMAND"
+
+docker run -it --rm \
+    -v $NPMRC_PATH:/root/.npmrc \
+    -v $PWD/packages/node:/app \
+    -w /app \
+    node:8.4-alpine \
+    $COMMAND


### PR DESCRIPTION
### Purpose
To move our npm package versioning inline with the version of this repo and the python package.

### Notes
I accidentally published this on the beta channel 🙈 - For the next version we should publish on stable!

Using the node alpine image for a much smaller and faster to install image.