### PR TITLE
added fields to track signup client, option, and if was paired with trial

### DIFF
--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -14,5 +14,13 @@ message Signup {
     Uuid client_id = 5;
     google.protobuf.Timestamp created_at = 4;
     string signup_option = 6;
+    enum signup_option {
+      EMAIL = 0;
+      FACEBOOK = 1;
+      TWITTER = 2;
+      LINKEDIN = 3;
+      GOOGLE = 4;
+      ORG_TEAM_INVITE = 5;
+    }
     bool with_trial = 7;
 }

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -5,14 +5,7 @@ package buda;
 import "buda/entities/uuid.proto";
 import "google/protobuf/timestamp.proto";
 
-
 message Signup {
-    Uuid id = 1;
-    Uuid user_id = 2;
-    Uuid visitor_id = 3;
-    Uuid legacy_visitor_id = 100; //buffer-web visitor_id, will be deprecated
-    Uuid client_id = 5;
-    google.protobuf.Timestamp created_at = 4;
     enum SignupOption {
       EMAIL = 0;
       FACEBOOK = 1;
@@ -21,12 +14,20 @@ message Signup {
       GOOGLE = 4;
       ORG_TEAM_INVITE = 5;
     }
-    SignupOption signup_option = 6;
-    bool with_trial = 7;
+
     enum Product {
         PUBLISH = 0;
         REPLY = 1;
         ANALYZE = 2;
     }
-    Product product = 7;
+
+    Uuid id = 1;
+    Uuid user_id = 2;
+    Uuid visitor_id = 3;
+    Uuid legacy_visitor_id = 100; //buffer-web visitor_id, will be deprecated
+    Uuid client_id = 5;
+    google.protobuf.Timestamp created_at = 4;
+    SignupOption signup_option = 6;
+    bool with_trial = 7;
+    Product product = 8;
 }

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -21,12 +21,19 @@ message Signup {
         ANALYZE = 2;
     }
 
+    enum SignupClient {
+        WEB = 0;
+        IOS = 1;
+        ANDROID = 2;
+        OTHER = 3;
+    }
+
     Uuid id = 1;
     Uuid user_id = 2;
     Uuid visitor_id = 3;
     Uuid legacy_visitor_id = 100; //buffer-web visitor_id, will be deprecated
-    Uuid client_id = 5;
     google.protobuf.Timestamp created_at = 4;
+    SignupClient signup_client = 5;
     SignupOption signup_option = 6;
     bool with_trial = 7;
     Product product = 8;

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -11,6 +11,8 @@ message Signup {
     Uuid user_id = 2;
     Uuid visitor_id = 3;
     Uuid legacy_visitor_id = 100; //buffer-web visitor_id, will be deprecated
-
+    Uuid client_id = 5;
     google.protobuf.Timestamp created_at = 4;
+    string signup_option = 6;
+    bool with_trial = 7;
 }

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -23,4 +23,10 @@ message Signup {
     }
     SignupOption signup_option = 6;
     bool with_trial = 7;
+    enum Product {
+        PUBLISH = 0;
+        REPLY = 1;
+        ANALYZE = 2;
+    }
+    Product product = 7;
 }

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -13,8 +13,7 @@ message Signup {
     Uuid legacy_visitor_id = 100; //buffer-web visitor_id, will be deprecated
     Uuid client_id = 5;
     google.protobuf.Timestamp created_at = 4;
-    string signup_option = 6;
-    enum signup_option {
+    enum SignupOption {
       EMAIL = 0;
       FACEBOOK = 1;
       TWITTER = 2;
@@ -22,5 +21,6 @@ message Signup {
       GOOGLE = 4;
       ORG_TEAM_INVITE = 5;
     }
+    SignupOption signup_option = 6;
     bool with_trial = 7;
 }


### PR DESCRIPTION
Heya @michael-erasmus and @djfarrelly :smile: ,
(cc @davidgasquez )

I’d love to hear any thoughts you might have on this!  I’m hoping we can start including a few more details in these signup events, which I have added in this PR.  

- client_id: the client id of where the user signed up from.  Currently we derive this from actions_taken, but we have quite a few events that come through there with no client_id so its a bit of a flawed data source.  Hopefully this would fix that. [Here is a Looker explore](https://looker.buffer.com/explore/users/users?qid=XOae9q0DLRj0nz9yBrKckx&toggle=fil) that shows the current data (we derive the client name from the client id).

- signup_option: the choice of signing up used (email, facebook, google, linkedin, twitter, org_team_invite, etc)

- with_trial: set as true if the user account was created from a workflow that also triggered a trial start.  For acquisition metric purposes, it would be really helpful to know when a user signedup from a workflow that also created a trial, vs a workflow where just a user account created (without a trial). 

I might be missing some context, or perhaps a better solution for the end goal :sweat_smile: , so would love any suggestions this might spark.  :smile:  