### PR TITLE
removed org prefix in SignupOption enum

### DIFF
--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -12,7 +12,7 @@ message Signup {
       TWITTER = 2;
       LINKEDIN = 3;
       GOOGLE = 4;
-      ORG_TEAM_INVITE = 5;
+      TEAM_INVITE = 5;
     }
 
     enum Product {


### PR DESCRIPTION
Heya @michael-erasmus and @djfarrelly :),
This is small tweak to drop the `org` prefix from `team_invite` in SignupOption, per conversations in https://github.com/bufferapp/buffer-js-buffermetrics/issues/27#issuecomment-369361569
