### PR TITLE
Signup enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ test-node:
 publish-node:
 	@./scripts/publish-node.sh
 
+.PHONY: publish-pre-node
+publish-node:
+	@./scripts/publish-pre-node.sh
+
 .PHONY: packages
 packages: package-node package-python
 

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -38,11 +38,11 @@ message Signup {
     Uuid visitor_id = 3;
     Uuid legacy_visitor_id = 100; //buffer-web visitor_id, will be deprecated
     google.protobuf.Timestamp created_at = 4;
-    SignupClient signup_client = 5;
-    SignupOption signup_option = 6;
+    SignupClient client = 5;
+    SignupOption option = 6;
     bool with_trial = 7;
     Product product = 8;
-    string signup_cta = 9;
+    string cta = 9;
     UserAgent user_agent = 10;
     Uuid client_id = 11;
 }

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -45,5 +45,4 @@ message Signup {
     string signup_cta = 9;
     UserAgent user_agent = 10;
     Uuid client_id = 11;
-
 }

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -44,5 +44,6 @@ message Signup {
     Product product = 8;
     string signup_cta = 9;
     UserAgent user_agent = 10;
-    
+    Uuid client_id = 11;
+
 }

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -18,9 +18,11 @@ message Signup {
 
     enum SignupClient {
         WEB = 0;
-        IOS = 1;
-        ANDROID = 2;
-        OTHER = 3;
+        PUBLISH = 1;
+        ANALYZE = 3;
+        IPHONE = 4;
+        ANDROID = 5;
+        OTHER = 6;
     }
 
 

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -23,6 +23,14 @@ message Signup {
         OTHER = 3;
     }
 
+
+    message UserAgent {
+        string browser = 1;
+        string version = 2;
+        string os = 3;
+        string device = 4;
+      }
+
     Uuid id = 1;
     Uuid user_id = 2;
     Uuid visitor_id = 3;
@@ -33,4 +41,6 @@ message Signup {
     bool with_trial = 7;
     Product product = 8;
     string signup_cta = 9;
+    UserAgent user_agent = 10;
+    
 }


### PR DESCRIPTION
Hey @mallen5311! 

As discussed, here are the recent changes I made to the signup protobuf.

- Added `PUBLISH` and `ANALYZE` signup clients
- Renamed `IOS` client enum to `IPHONE` (this matches the name we use in the buffer web [here](https://github.com/bufferapp/buffer-web/blob/master/shared/config/production/clients.php#L8))
- Also track the `client_id`
- Added a `user_agent` field, with an `os` and `device` field 