### PR TITLE
Task/add account id

### DIFF
--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -18,8 +18,8 @@ message Signup {
 
     enum SignupClient {
         WEB = 0;
-        PUBLISH = 1;
-        ANALYZE = 3;
+        // PUBLISH = 1; --deprecated value
+        // ANALYZE = 3; --deprecated value
         IPHONE = 4;
         ANDROID = 5;
         OTHER = 6;

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -18,8 +18,6 @@ message Signup {
 
     enum SignupClient {
         WEB = 0;
-        // PUBLISH = 1; --deprecated value
-        // ANALYZE = 3; --deprecated value
         IPHONE = 4;
         ANDROID = 5;
         OTHER = 6;

--- a/buda/entities/signup.proto
+++ b/buda/entities/signup.proto
@@ -45,4 +45,5 @@ message Signup {
     string cta = 9;
     UserAgent user_agent = 10;
     Uuid client_id = 11;
+    Uuid account_id = 12;
 }


### PR DESCRIPTION
Heya @michael-erasmus 👋 

Here are two changes we talked about:
1) deprecated the `analyze` and `publish` values from the signupClient enum
2) added account id 

